### PR TITLE
feat: supplement methods

### DIFF
--- a/nftproject/contracts/NFT.vy
+++ b/nftproject/contracts/NFT.vy
@@ -8,12 +8,11 @@ implements: ERC721
 
 ############ ERC-165 #############
 # @dev Static list of supported ERC165 interface ids
-SUPPORTED_INTERFACES: constant(bytes4[6]) = [
+SUPPORTED_INTERFACES: constant(bytes4[5]) = [
     0x01ffc9a7,  # interface ID of ERC165
     0x80ac58cd,  # interface ID of ERC721
     0x5b5e139f,  # interface ID of ERC721 Metadata Extension
     0x5604e225,  # interface ID of ERC 4494
-    0x150b7a02,  # interface ID of ERC721 Token Receiever
     0x780e9d63,  # interface ID if ERC721 Enuermable
 ]
 
@@ -22,10 +21,10 @@ SUPPORTED_INTERFACES: constant(bytes4[6]) = [
 # Interface for the contract called by safeTransferFrom()
 interface ERC721Receiver:
     def onERC721Received(
-        _operator: address,
-        _owner: address,
-        _tokenId: uint256,
-        _data: Bytes[1024]
+        operator: address,
+        owner: address,
+        tokenId: uint256,
+        data: Bytes[1024]
     ) -> bytes32: view
 
 # Interface for ERC721Metadata
@@ -36,7 +35,7 @@ interface ERC721Metadata:
 	def symbol() -> String[32]: view
 
 	def tokenURI(
-		_tokenId: uint256
+		tokenId: uint256
 	) -> String[128]: view
 
 interface ERC721Enumerable:
@@ -44,12 +43,12 @@ interface ERC721Enumerable:
 	def totalSupply() -> uint256: view
 
 	def tokenByIndex(
-		_index: uint256
+		index: uint256
 	) -> uint256: view
 
 	def tokenOfOwnerByIndex(
-		_address: address,
-		_index: uint256
+		owner: address,
+		index: uint256
 	) -> uint256: view
 
 
@@ -91,14 +90,11 @@ tokenName: immutable(String[64])
 tokenSymbol: immutable(String[32])
 baseTokenURI: immutable(String[64])
 
-# @dev current count of token
-tokenId: uint256
+# @dev current number of tokens
+totalSupply: uint256
 
 # @dev Maximum supply of token
-maxSupply: public(uint256)
-
-# @dev count of burnt tokens
-burntCount: uint256
+MAX_SUPPLY: constant(uint256) = 10000
 
 # @dev creator of contract
 owner: public(address)
@@ -118,29 +114,11 @@ balanceOf: public(HashMap[address, uint256])
 # @dev Mapping from owner address to mapping of operator addresses.
 isApprovedForAll: public(HashMap[address, HashMap[address, bool]])
 
-# @dev Mapping from index to token ID
-indexToTokenId: HashMap[uint256, uint256]
-
-# @dev Mapping from token ID to index
-tokenIdToIndex: HashMap[uint256, uint256]
-
-# @dev Mapping from owner address to count of his tokens.
-ownerToNFTokenCount: HashMap[address, uint256]
-
-# @dev Mapping from owner address to mapping of index to tokenIds
-ownerToNFTokenIdList: HashMap[address, HashMap[uint256, uint256]]
-
-# @dev Mapping from NFT ID to index of owner
-tokenToOwnerIndex: HashMap[uint256, uint256]
-
 # @dev Mapping from owner address to mapping of operator addresses.
 ownerToOperators: HashMap[address, HashMap[address, bool]]
 
 #@dev Maping from NFT ID to token URI
 idToURI: HashMap[uint256, String[64]]
-
-# @dev Address of minter, who can mint a token
-minter: address
 
 ############ ERC-4494 ############
 
@@ -161,20 +139,17 @@ IDENTITY_PRECOMPILE: constant(address) = 0x0000000000000000000000000000000000000
 
 @external
 def __init__(
-    _name: String[64],
-    _symbol: String[32],
-    _baseURI: String[64],
-    _maxSupply: uint256,
-    _minter: address
+    name: String[64],
+    symbol: String[32],
+    baseURI: String[64],
 ):
     """
     @dev Contract constructor.
     """
-    tokenName = _name
-    tokenSymbol = _symbol
-    baseTokenURI = _baseURI
-    self.maxSupply = _maxSupply
-    self.minter = _minter
+    tokenName = name
+    tokenSymbol = symbol
+    baseTokenURI = baseURI
+    self.owner = msg.sender
     # ERC712 domain separator for ERC4494
     self.DOMAIN_SEPARATOR = keccak256(
         _abi_encode(
@@ -202,14 +177,14 @@ def baseURI() -> String[64]:
     return baseTokenURI
 
 @internal
-def _uint_to_string(_value: uint256) -> String[78]:
+def _uint_to_string(val: uint256) -> String[78]:
     """
     @dev skelletOr
     reference: https://github.com/curvefi/curve-veBoost/blob/0e51be10638df2479d9e341c07fafa940ef58596/contracts/VotingEscrowDelegation.vy#L423
     """
     # NOTE: Odd that this works with a raw_call inside, despite being marked
     # a pure function
-    if _value == 0:
+    if val == 0:
         return "0"
 
     buffer: Bytes[78] = b""
@@ -218,11 +193,11 @@ def _uint_to_string(_value: uint256) -> String[78]:
     for i in range(78):
         # go forward to find the # of digits, and set it
         # only if we have found the last index
-        if digits == 78 and _value / 10 ** i == 0:
+        if digits == 78 and val / 10 ** i == 0:
             digits = i
 
-        value: uint256 = ((_value / 10 ** (77 - i)) % 10) + 48
-        char: Bytes[1] = slice(convert(value, bytes32), 31, 1)
+        char_int: uint256 = ((val / 10 ** (77 - i)) % 10) + 48
+        char: Bytes[1] = slice(convert(char_int, bytes32), 31, 1)
         buffer = raw_call(
             IDENTITY_PRECOMPILE,
             concat(buffer, char),
@@ -232,10 +207,12 @@ def _uint_to_string(_value: uint256) -> String[78]:
 
     return convert(slice(buffer, 78 - digits, digits), String[78])
 
+
 @external
-def tokenURI(_tokenId: uint256) -> String[179]:
-    return concat(baseTokenURI, "/" , self._uint_to_string(_tokenId))
-       
+def tokenURI(tokenId: uint256) -> String[143]:
+    return concat(baseTokenURI, "/" , self._uint_to_string(tokenId))
+
+
 @external
 def setDomainSeparator():
     """
@@ -291,57 +268,64 @@ def getApproved(tokenId: uint256) -> address:
     assert self.idToOwner[tokenId] != ZERO_ADDRESS
     return self.idToApprovals[tokenId]
 
-@view
-@internal
-def _totalSupply() -> uint256:
-    """
-    @dev Returns total supply
-    """
-    return self.tokenId - self.burntCount
 
 @view
 @external
-def totalSupply() -> uint256:
-    """
-    @dev Returns total supply
-    """
-    return self._totalSupply()
-    
-@view
-@internal
-def _balanceOf(_owner: address) -> uint256:
-    """
-    @dev 	Returns number of tokens held by '_owner'
-    		Throws if '_owner' is ZERO_ADDRESS.
-    @param 	_owner Address to query
-    """
-    assert _owner != ZERO_ADDRESS
-    return self.ownerToNFTokenCount[_owner]
-
-@view
-@external
-def tokenByIndex(_index: uint256) -> uint256:
+def tokenByIndex(index: uint256) -> uint256:
     """
     @dev Get token by index
-         Throws if '_index' is larger than totalSupply()
+         Throws if 'index' is larger than totalSupply()
     """
-    assert _index <= self._totalSupply() - self.burntCount
-    assert _index > 0
+    # NOTE: This is more gas-heavy than maintaining the properties in storage.
+    #       However, we almost always reference this value off-chain,
+    #       so the cost doesn't matter.
+    assert index <= self.totalSupply  # NOTE: This prevents indexing un-minted tokens
+    assert index > 0
 
-    return self.indexToTokenId[_index]
+    burnt_offset: uint256 = 0
+    for raw_idx in range(MAX_SUPPLY):
+        # Iterated over all possible mintable tokens (may not be minted yet)
+        if self.idToOwner[raw_idx] == ZERO_ADDRESS:
+            # This token has been burnt or not minted yet
+            burnt_offset += 1
+        
+        if raw_idx - burnt_offset == index:
+            #return raw_idx
+            break
+
+    return index + burnt_offset
+    #raise UNREACHABLE  # Shouldn't ever reach this (see NOTE above)
+
 
 @view
 @external
-def tokenOfOwnerByIndex(_owner: address, _index: uint256) -> uint256:
+def tokenOfOwnerByIndex(owner: address, index: uint256) -> uint256:
     """
     @dev Get token by index
-         Throws if '_index' is larger than balance of '_owner'
+         Throws if 'index' is larger than balance of 'owner'
          Throws if value has been set to 0
     """
-    assert _index <= self._balanceOf(_owner)
-    assert self.ownerToNFTokenIdList[_owner][_index] != 0
+    # NOTE: This is more gas-heavy than maintaining the properties in storage.
+    #       However, we almost always reference this value off-chain,
+    #       so the cost doesn't matter.
+    # NOTE: invariant `balanceOf(owner) <= totalSupply`
+    assert index <= self.balanceOf[owner]  # NOTE: This prevents indexing un-minted tokens
+    assert index > 0
 
-    return self.ownerToNFTokenIdList[_owner][_index]
+    owner_offset: uint256 = 0
+    for raw_idx in range(MAX_SUPPLY):
+        # Iterated over all possible mintable tokens (may not be minted yet)
+        if self.idToOwner[raw_idx] != owner:
+            # This token is not owned by `owner`
+            # NOTE: This also avoids burnt tokens as well as ones that are not minted yet
+            owner_offset += 1
+        
+        if raw_idx - owner_offset == index:
+            #return raw_idx
+            break
+    return index + owner_offset
+
+    #raise UNREACHABLE  # Shouldn't ever reach this (see NOTE above)
 
 ### TRANSFER FUNCTION HELPERS ###
 
@@ -374,8 +358,8 @@ def _transferFrom(owner: address, receiver: address, tokenId: uint256, sender: a
     """
     @dev Execute transfer of a NFT.
          Throws unless `msg.sender` is the current owner, an authorized operator, or the approved
-         address for this NFT. (NOTE: `msg.sender` not allowed in private function so pass `_sender`.)
-         address for thisassert self.idToOwner[tokenId] == owner NFT. (NOTE: `msg.sender` not allowed in private function so pass `_sender`.)
+         address for this NFT. (NOTE: `msg.sender` not allowed in private function so pass `sender`.)
+         address for thisassert self.idToOwner[tokenId] == owner NFT. (NOTE: `msg.sender` not allowed in private function so pass `sender`.)
          Throws if `receiver` is the zero address.
          Throws if `owner` is not the current owner.
          Throws if `tokenId` is not a valid NFT.
@@ -422,10 +406,10 @@ def transferFrom(owner: address, receiver: address, tokenId: uint256):
 
 @external
 def safeTransferFrom(
-        _owner: address,
-        _receiver: address,
-        _tokenId: uint256,
-        _data: Bytes[1024]=b""
+        owner: address,
+        receiver: address,
+        tokenId: uint256,
+        data: Bytes[1024]=b""
     ):
     """
     @dev Transfers the ownership of an NFT from one address to another address.
@@ -437,14 +421,14 @@ def safeTransferFrom(
          If `receiver` is a smart contract, it calls `onERC721Received` on `receiver` and throws if
          the return value is not `bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"))`.
          NOTE: bytes4 is represented by bytes32 with padding
-    @param _owner The current owner of the NFT.
-    @param _receiver The new owner.
-    @param _tokenId The NFT to transfer.
-    @param _data Additional data with no specified format, sent in call to `receiver`.
+    @param owner The current owner of the NFT.
+    @param receiver The new owner.
+    @param tokenId The NFT to transfer.
+    @param data Additional data with no specified format, sent in call to `receiver`.
     """
-    self._transferFrom(_owner, _receiver, _tokenId, msg.sender)
-    if _receiver.is_contract: # check if `receiver` is a contract address
-        returnValue: bytes32 = ERC721Receiver(_receiver).onERC721Received(msg.sender, _owner, _tokenId, _data)
+    self._transferFrom(owner, receiver, tokenId, msg.sender)
+    if receiver.is_contract: # check if `receiver` is a contract address
+        returnValue: bytes32 = ERC721Receiver(receiver).onERC721Received(msg.sender, owner, tokenId, data)
         # Throws if transfer destination is a contract which does not implement 'onERC721Received'
         assert returnValue == method_id("onERC721Received(address,address,uint256,bytes)", output_type=bytes32)
 
@@ -473,16 +457,16 @@ def approve(operator: address, tokenId: uint256):
     log Approval(owner, operator, tokenId)
 
 @internal
-def _clearApproval(_owner: address, _tokenId: uint256):
+def _clearApproval(owner: address, tokenId: uint256):
     """
     @dev Clear an approval of a given address
-         Throws if `_owner` is not the current owner.
+         Throws if `owner` is not the current owner.
     """
-    # Throws if `_owner` is not the current owner
-    assert self.idToOwner[_tokenId] == _owner
-    if self.idToApprovals[_tokenId] != ZERO_ADDRESS:
+    # Throws if `owner` is not the current owner
+    assert self.idToOwner[tokenId] == owner
+    if self.idToApprovals[tokenId] != ZERO_ADDRESS:
         # Reset approvals
-        self.idToApprovals[_tokenId] = ZERO_ADDRESS
+        self.idToApprovals[tokenId] = ZERO_ADDRESS
 
 @external
 def permit(spender: address, tokenId: uint256, deadline: uint256, sig: Bytes[65]) -> bool:
@@ -568,93 +552,56 @@ def setApprovalForAll(operator: address, approved: bool):
     """
     self.isApprovedForAll[msg.sender][operator] = approved
     log ApprovalForAll(msg.sender, operator, approved)
+
+
 @external
 def addMinter(minter: address):
     assert msg.sender == self.owner
     self.isMinter[minter] = True
 
+
 @internal
-def _setTokenURI(_tokenId: uint256, _tokenURI: String[64]):
+def _setTokenURI(tokenId: uint256, tokenURI: String[64]):
     """
     @dev Set the URI for a token
          Throws if the token ID does not exist
     """
-    assert self.idToOwner[_tokenId] != ZERO_ADDRESS
+    assert self.idToOwner[tokenId] != ZERO_ADDRESS
+    self.idToURI[tokenId] = tokenURI
 
-    self.idToURI[_tokenId] = _tokenURI
 
 @internal
-def _mint(_receiver: address, _tokenURI: String[64]) -> bool:
+def _mint(receiver: address, tokenId: uint256) -> bool:
     """
     @dev Function to mint tokens
-         Throws if `_to` is zero address.
-         Throws if `_tokenId` is owned by someone.
-    @param _receiver The address that will receive the minted tokens.
-    @param _tokenURI The token URI
+         Throws if `receiver` is zero address.
+         Throws if `tokenId` is owned by someone.
+    @param receiver The address that will receive the minted tokens.
+    @param tokenURI The token URI
     @return A boolean that indicates if the operation was successful.
     """
-    # Throws if `_to` is zero address
-    assert _receiver != ZERO_ADDRESS
+    # Throws if 'tokenId' is equal to or greater than 'self.maxSupply'
+    assert self.totalSupply < MAX_SUPPLY
 
-    # Throws if '_tokenId' is equal to or greater than 'self.maxSupply'
-    assert self.tokenId < self.maxSupply
+    self.idToOwner[tokenId] = receiver
+    self.balanceOf[receiver] += 1
+    self.totalSupply += 1
 
-    # Add NFT. Throws if `_tokenId` is owned by someone
-    self.tokenId += 1
-    _tokenId: uint256 = self.tokenId
-
-    current_index: uint256 = self._totalSupply() - self.burntCount
-
-    self.indexToTokenId[current_index] = _tokenId
-    self.tokenIdToIndex[_tokenId] = current_index
-    self._setTokenURI(_tokenId, _tokenURI)
-    log Transfer(ZERO_ADDRESS, _receiver, _tokenId)
-
+    log Transfer(ZERO_ADDRESS, receiver, tokenId)
     return True
 
+
 @external
-def mint(_receiver: address, _tokenURI: String[64]) -> bool:
+def mint(receiver: address) -> bool:
     """
-    @dev Create a new Owner NFT
+    @dev Create a new NFT and give to `receiver`
     @notice `tokenId` cannot be owned by someone because of hash production.
     @return uint256 Computed TokenID of new Portfolio.
     """
 
     assert msg.sender == self.owner or self.isMinter[msg.sender], "Access is denied."
-    assert _receiver != ZERO_ADDRESS
+    assert receiver != ZERO_ADDRESS
 
-    self._mint(_receiver, _tokenURI)
+    self._mint(receiver, self.totalSupply)
     
     return True
-
-@external
-def burn(_tokenId: uint256):
-    """
-    @dev Burns a specific ERC721 token.
-         Throws unless `msg.sender` is the current owner, an authorized operator, or the approved
-         address for this NFT.
-         Throws if `_tokenId` is not a valid NFT.
-    @param _tokenId uint256 id of the ERC721 token to be burned.
-    """
-    # Check requirements
-    assert self._isApprovedOrOwner(msg.sender, _tokenId)
-    owner: address = self.idToOwner[_tokenId]
-    # Throws if `_tokenId` is not a valid NFT
-    assert owner != ZERO_ADDRESS
-    self._clearApproval(owner, _tokenId)
-    current_index: uint256 = self.tokenIdToIndex[_tokenId]
-    last_index: uint256 = self._totalSupply() - self.burntCount
-
-    last_index_token_id: uint256 = self.indexToTokenId[last_index]
-
-    # Set last index to current index
-    self.indexToTokenId[current_index] = last_index_token_id
-    self.tokenIdToIndex[last_index_token_id] = current_index
-
-    # Remove burnt token from mapping of token ID to index
-    self.tokenIdToIndex[_tokenId] = 0
-
-	# Increment coun of burnt tokens
-    self.burntCount += 1
-
-    log Transfer(owner, ZERO_ADDRESS, _tokenId)


### PR DESCRIPTION
We have a very standard ERC721 vyper contract. We don't have non standard methods to work with
ie. Mint, Burn, etc


The goal for this feature is to add supplemental methods to make it more relevant to our user base.

after we agree on which methods to add, I will make a video part 2 for erc721

Which will include:

- Explanation of Supplemental Methods
- Deployment of NFT on OpenSea
- Config file for default Ape Icon and ipfs link for coming soon


The info I used to make the supplements can be found here:
https://github.com/tserg/vyper-contracts/blob/main/contracts/ERC721.vy